### PR TITLE
Fix system dependent headers/macros definition and add a channel chec…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# C++ objects and libs
+
+*.slo
+*.lo
+*.o
+*.a
+*.la
+*.lai
+*.so
+*.dll
+*.dylib
+
+# Qt-es
+
+/.qmake.cache
+/.qmake.stash
+*.pro.user
+*.pro.user.*
+*.qbs.user
+*.qbs.user.*
+*.moc
+moc_*.cpp
+qrc_*.cpp
+ui_*.h
+Makefile*
+*build-*
+
+# QtCreator
+
+*.autosave
+
+# QtCtreator Qml
+*.qmlproject.user
+*.qmlproject.user.*
+
+# QtCtreator CMake
+CMakeLists.txt.user
+

--- a/wifi_deauth.cpp
+++ b/wifi_deauth.cpp
@@ -27,6 +27,8 @@ WifiDeauth::WifiDeauth(std::string _ifaceTrigger, std::string _ifaceScanner, uin
     : ifaceTrigger(_ifaceTrigger), ifaceScanner(_ifaceScanner), rangeNet(Tins::IPv4Range::from_mask(ipNet, infoScanner.netmask)),
       strSniffer(_ifaceTrigger), channel(_channel){}
 
+
+//Sniffer callback function for 'listingAP()'
 bool WifiDeauth::callbackSniff(Tins::PDU &pdu) {
     const Tins::Dot11Beacon &beacon = pdu.rfind_pdu<Tins::Dot11Beacon>();
     if (!beacon.from_ds() && !beacon.to_ds()) {
@@ -39,6 +41,7 @@ bool WifiDeauth::callbackSniff(Tins::PDU &pdu) {
     return true;
 }
 
+//This method finds 802.11 Beacon(AP) PDU captured from a monitor interface.
 void WifiDeauth::listingAP(){
     Tins::SnifferConfiguration confSniff;
     confSniff.set_promisc_mode(true);
@@ -55,6 +58,7 @@ void WifiDeauth::scanVictims(){
             std::cout << std::endl << "[!] ARP Scanning Start... [ Estimate Time : " <<
                          (std::distance(rangeNet.begin(), rangeNet.end()) * 2) << "sec ]" << std::endl;
 
+    //Do ARP Scanning to all IP range addresses.
     for(const auto &target : rangeNet) {
         Tins::EthernetII scan = Tins::ARP::make_arp_request(target, infoScanner.ip_addr, infoScanner.hw_addr);
         std::unique_ptr<Tins::PDU> reply(sender.send_recv(scan, ifaceScanner));
@@ -68,7 +72,7 @@ void WifiDeauth::scanVictims(){
 
 void WifiDeauth::deauthVictims(){
     std::cout << std::endl << "[!] Deauthentication Start... [ Press Ctrl+C to Exit ]" << std::endl;
-    radio.channel(Tins::Utils::channel_to_mhz(channel), 0x00a0);
+    radio.channel(Tins::Utils::channel_to_mhz(channel), 0x00a0); //2407 + channel * 5, 0x00a0(802.11b)
     while(1){
         for(const auto &apTarget : vecFinalAP){
             deauth.addr1(apTarget);

--- a/wifi_deauth.h
+++ b/wifi_deauth.h
@@ -24,17 +24,12 @@
 #ifndef WIFI_DEAUTH_H
 #define WIFI_DEAUTH_H
 
-#ifdef __linux__
-#include <sys/stat.h>
-#include <sys/types.h>
-#endif
-
 #include <iostream>
 #include <algorithm>
 #include <map>
 #include <vector>
+#include <cstdint>
 #include <tins/tins.h>
-#include <unistd.h>
 
 class WifiDeauth
 {


### PR DESCRIPTION
1. Change 'unistd.h'(for static size variables) to 'cstdint' header.

2.Change '#ifdef' macro to '#if defined(...)' macro (For OSX compatibility)
2-1. Also, move system dependent definitions to 'main.cpp' from 'wifi_deauth.h'
Before

``` cpp
#ifdef __linux__
#define NIC_LOCATION "/sys/class/net/"
#endif
```

After

``` cpp
#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
#include <sys/stat.h>
#include <sys/types.h>
#define NIC_LOCATION "/sys/class/net/"

#elif defined(__WIN32)
#endif
```

Before

``` cpp
#ifdef __linux__
  struct stat sb;
  char path_name[100];

  snprintf(path_name, sizeof(path_name), "%s%s", NIC_LOCATION, nic_name);
  if (stat(path_name, &sb) == 0 && S_ISLNK(sb.st_mode) == 0) {
    return true;
  }

  return false;
#else
  // If unsupported environment, Not the network interface exist check.
  return true;
#endif
```

After

``` cpp
#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
  struct stat sb;
  char path_name[100];

  snprintf(path_name, sizeof(path_name), "%s%s", NIC_LOCATION, nic_name);
  if (stat(path_name, &sb) == 0 && S_ISLNK(sb.st_mode) == 0) {
    return true;
  }

  return false;

#elif defined(__WIN32)

  return true;
#else
  // If unsupported environment, Not the network interface exist check.
  return true;
#endif
```
1. Add '.gitignore' file for QtCreator

P.S. - I added some remarks :)
